### PR TITLE
Modifications to pylintrc and makefile

### DIFF
--- a/bin/factory.py
+++ b/bin/factory.py
@@ -3,7 +3,6 @@ This module holds the factory class.
 '''
 import sys
 sys.path.append('.')
-
 from bin.wsj import GainerDownloadWSJ, GainerProcessWSJ
 from bin.yahoo import GainerDownloadYahoo, GainerProcessYahoo
 
@@ -16,7 +15,7 @@ class GainerFactory:
         '''
         Init method for the factory class for the gainers.
         '''
-        assert choice in ['yahoo', 'wsj', 'test'], f"Unrecognized gainer type {choice}"
+        assert choice in ['yahoo', 'wsj'], f"Unrecognized gainer type {choice}"
         self.choice = choice
 
     def get_downloader(self):
@@ -25,18 +24,17 @@ class GainerFactory:
         '''
         # trigger off url to return correct downloader
         if self.choice == 'yahoo':
-            return GainerDownloadYahoo()
-        elif self.choice == 'wsj':
-            return GainerDownloadWSJ()
-        else: return None
+            download_var = GainerDownloadYahoo()
+        else:
+            download_var = GainerDownloadWSJ()
+        return download_var
 
     def get_processor(self):
         '''
         Gets the processor specific to the data source. Method for the factory class.
         '''
-        # trigger off url to return correct downloader
         if self.choice == 'yahoo':
-            return GainerProcessYahoo()
-        elif self.choice == 'wsj':
-            return GainerProcessWSJ()
-        else: return None
+            process_var = GainerProcessYahoo()
+        else:
+            process_var = GainerProcessWSJ()
+        return process_var

--- a/bin/wsj.py
+++ b/bin/wsj.py
@@ -39,7 +39,8 @@ class GainerDownloadWSJ(GainerDownload):
 capture_output=True, text=True, check=True, shell=False)
         tz = timezone('US/Eastern')
         now = datetime.now(tz)
-        self.raw_df = pd.read_csv(f'wsjgainers_{now.year}_{now.month}_{now.day}_{now.hour}_{now.minute}.csv')
+        format_time = f'{now.year}_{now.month}_{now.day}_{now.hour}_{now.minute}'
+        self.raw_df = pd.read_csv(f'wsjgainers_{format_time}.csv')
         return self.raw_df
 
 class GainerProcessWSJ(GainerProcess):

--- a/bin/yahoo.py
+++ b/bin/yahoo.py
@@ -40,7 +40,8 @@ class GainerDownloadYahoo(GainerDownload):
 capture_output=True, text=True, check=True, shell=False)
         tz = timezone('US/Eastern')
         now = datetime.now(tz)
-        self.raw_df = pd.read_csv(f'ygainers_{now.year}_{now.month}_{now.day}_{now.hour}_{now.minute}.csv')
+        format_time = f'{now.year}_{now.month}_{now.day}_{now.hour}_{now.minute}'
+        self.raw_df = pd.read_csv(f'ygainers_{format_time}.csv')
         return self.raw_df
 
 # Processor

--- a/makefile
+++ b/makefile
@@ -21,11 +21,11 @@ wsjgainers.csv: wsjgainers.html
 
 lint:
 	pylint bin/normalize_csv.py
-	#pylint get_gainer.py ## for some reason, this python version throws an error anywhere "bin.[package name]" is imported.
+	pylint get_gainer.py
 	pylint bin/base.py
-	#pylint bin/factory.py
-	#pylint bin/yahoo.py
-	#pylint bin/wsj.py
+	pylint bin/factory.py
+	pylint bin/yahoo.py
+	pylint bin/wsj.py
 
 test: lint
 	pytest -vv tests

--- a/pylintrc
+++ b/pylintrc
@@ -1,4 +1,5 @@
 [MAIN]
+init-hook='import sys; sys.path.append("."); from abc import ABC, abstractmethod'
 
 # Analyse import fallback blocks. This can be used to support both Python 2 and
 # 3 compatible code, which means that the block might have code that exists
@@ -438,7 +439,10 @@ disable=raw-checker-failed,
         deprecated-pragma,
         use-symbolic-message-instead,
         use-implicit-booleaness-not-comparison-to-string,
-        use-implicit-booleaness-not-comparison-to-zero
+        use-implicit-booleaness-not-comparison-to-zero, 
+        C0413,
+        W0221, 
+        W0231
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option


### PR DESCRIPTION
Files modified include the pylintrc, makefile, and certain modules in the bin directory - factory, yahoo, and wsj - so that they will pass the linting. The makefile was modified with these files uncommented out, after making modifications to the pylintrc. In the pylintrc file, I added the ability for linting to read imports using the "sys" command. I also added a couple errors to the "disable=" line. Two of the disabled errors appeared to not correctly catch that we used abstract classes, and the other was related to the positioning of package imports, which could not be before the "sys.path.append('.')" statement.